### PR TITLE
各種Warningの対応

### DIFF
--- a/Rust/hello_actix_web/src/fizzbuzz.rs
+++ b/Rust/hello_actix_web/src/fizzbuzz.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-pub fn fizzbuzz(num: u32) -> String {
+pub fn fizzbuzz_checker(num: u32) -> String {
     if num % 15 == 0 {
         "FizzBuzz".to_string()
     } else if num % 3 == 0 {
@@ -12,7 +12,7 @@ pub fn fizzbuzz(num: u32) -> String {
     }
 }
 
-fn fib_memo(num: u32, memo: &mut HashMap<u32, u128>) -> u128 {
+pub fn fib_memo(num: u32, memo: &mut HashMap<u32, u128>) -> u128 {
     if let Some(&result) = memo.get(&num) {
         return result;
     }

--- a/Rust/hello_actix_web/src/four_arithmetic_operations.rs
+++ b/Rust/hello_actix_web/src/four_arithmetic_operations.rs
@@ -1,11 +1,9 @@
 use meval::eval_str;
-use regex::Regex;
-use std::str::FromStr;
 use urlencoding::decode;
 
 pub fn evaluate_expression(expression: &str) -> Result<f64, String> {
     let decoded_expr = decode(expression)
         .map_err(|_| "Failed to decode URL".to_string())?
         .into_owned(); // `Cow<str>` を `String` に変換
-    eval_str(&decoded_expr).map_err(|e| format!("Invalid expression format"))
+    eval_str(&decoded_expr).map_err(|_e| format!("Invalid expression format"))
 }

--- a/Rust/hello_actix_web/src/lib.rs
+++ b/Rust/hello_actix_web/src/lib.rs
@@ -4,6 +4,7 @@ pub mod models;
 pub mod prime;
 pub mod four_arithmetic_operations; //ファイルを指定
 use crate::models::BmiResponse;
+use crate::fizzbuzz::fizzbuzz_checker; // モジュールを指定
 
 
 #[get("/health")]
@@ -24,7 +25,7 @@ pub async fn fizzbuzz_endpoint(path: web::Path<String>) -> impl Responder {
     match raw.parse::<u32>() {
         Ok(num) => {
             // 正常に u32 化できたので fizzbuzz などの処理
-            let result = fizzbuzz::fizzbuzz(num);
+            let result = fizzbuzz_checker(num);
             HttpResponse::Ok().body(result)
         }
         Err(e) => {
@@ -85,7 +86,7 @@ pub async fn prime_endpoint(path: web::Path<String>) -> impl Responder {
                 let result = prime::nth_primes(num);
                 return HttpResponse::Ok().json(result);
             }
-            let result = prime::getPrime(num);
+            let result = prime::get_prime(num);
             HttpResponse::Ok().json(result)
         }
         Err(_) => {
@@ -94,7 +95,7 @@ pub async fn prime_endpoint(path: web::Path<String>) -> impl Responder {
     }
 }
 
-#[get("/four_arithmetic_operations/{str}")]
+#[get("/four_arithmetic_operations/{expr}")]
 pub async fn four_arithmetic_operations_endpoint(path: web::Path<String>) -> impl Responder {
     let raw = path.into_inner();
     match four_arithmetic_operations::evaluate_expression(&raw) {

--- a/Rust/hello_actix_web/src/prime.rs
+++ b/Rust/hello_actix_web/src/prime.rs
@@ -1,8 +1,7 @@
 // n番目までの素数を返す
-use std::cmp;
 use std::f64;
 
-pub fn getPrime(n: usize) -> Vec<u32> {
+pub fn get_prime(n: usize) -> Vec<u32> {
     let mut primes = vec![];
     let mut num = 2;
 

--- a/Rust/hello_actix_web/tests/fizzbuzz_test.rs
+++ b/Rust/hello_actix_web/tests/fizzbuzz_test.rs
@@ -1,14 +1,9 @@
-use hello_actix_web::fizzbuzz::fizzbuzz;
+use hello_actix_web::fizzbuzz::fizzbuzz_checker;
 
 #[test]
 fn test_fizzbuzz() {
-    let cases = [
-        (3, "Fizz"),
-        (5, "Buzz"),
-        (15, "FizzBuzz"),
-        (7, "7"),
-    ];
+    let cases = [(3, "Fizz"), (5, "Buzz"), (15, "FizzBuzz"), (7, "7")];
     for (input, expected) in cases {
-        assert_eq!(fizzbuzz(input), expected);
+        assert_eq!(fizzbuzz_checker(input), expected);
     }
 }

--- a/Rust/hello_actix_web/tests/four_arithmetic_operations_test.rs
+++ b/Rust/hello_actix_web/tests/four_arithmetic_operations_test.rs
@@ -1,7 +1,5 @@
 use actix_web::{test, http::StatusCode, App};
 use hello_actix_web::{health_check, hello, four_arithmetic_operations_endpoint};
-use serde_json::json;
-use serde_json::Value;
 
 #[actix_web::test]
 async fn test_four_arithmetic_operations_endpoint() {

--- a/Rust/hello_actix_web/tests/prime_test.rs
+++ b/Rust/hello_actix_web/tests/prime_test.rs
@@ -1,4 +1,4 @@
-use hello_actix_web::prime::getPrime;
+use hello_actix_web::prime::get_prime;
 use hello_actix_web::prime::nth_primes;
 
 #[test]
@@ -11,7 +11,7 @@ fn test_prime() {
         (5, vec![2, 3, 5, 7, 11]),
     ];
     for (input, expected) in cases {
-        assert_eq!(getPrime(input), expected);
+        assert_eq!(get_prime(input), expected);
     }
 }
 


### PR DESCRIPTION
ただしwarning: function `xxxxxxxxxxx` is never usedは全然治らず断念。